### PR TITLE
removed 6.851 from Term 1 data structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ Inspired by [The Open-Source Data Science Masters](https://github.com/datascienc
 
 > [Stanford CS106B](https://itunes.apple.com/in/course/programming-abstractions/id495054099)  
 > *or*  
-> [MIT 6.851](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-851-advanced-data-structures-spring-2012/)  
-> *or*  
 > [UC Berkeley CS61B](http://webcast.berkeley.edu/series.html#c,d,Computer_Science)
 
 **Computer Architecture**


### PR DESCRIPTION
MIT 6.851 is an advanced data structures class. There's no way it should be considered for a Term 1 data structure class, as it is a graduate level class that requires previous data structure knowledge.

I think it's a worthwhile class to take if you have the experience required, but I'm not sure it's appropriate for this open source degree, since this seems to be an undergraduate open source CS degree.