### PR TITLE
Updated link to Stanford CS 106B

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Inspired by [The Open-Source Data Science Masters](https://github.com/datascienc
 
 **Data Structures**
 
-> [Stanford CS106B](https://itunes.apple.com/in/course/programming-abstractions/id495054099)  
+> [Stanford CS106B](http://web.stanford.edu/class/cs106b/lectures.shtml)  
 > *or*  
 > [UC Berkeley CS61B](http://webcast.berkeley.edu/series.html#c,d,Computer_Science)
 


### PR DESCRIPTION
The iTunes page no longer has a subscribe button and all material on iTunes are unavailable