### PR TITLE
Fix outdated course resource links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ Inspired by [The Open-Source Data Science Masters](https://github.com/datascienc
 
 **UX Design**
 
-> [Interaction Design Foundation — UX Design Fundamentals](https://www.interaction-design.org/courses/user-experience-the-beginner-s-guide)
+> [Interaction Design Foundation — UX Design Fundamentals](https://ixdf.org/courses/user-experience-the-beginner-s-guide)
 
 **Intro to Web Development**
 
 > [The Odin Project — Full Stack](https://www.theodinproject.com/)  
 > *or*  
-> [freeCodeCamp — Responsive Web Design](https://www.freecodecamp.org/learn/2022/responsive-web-design/)
+> [freeCodeCamp — Responsive Web Design](https://www.freecodecamp.org/learn/2022/responsive-web-design)
 
 **Intro to Databases**
 
@@ -110,7 +110,7 @@ Inspired by [The Open-Source Data Science Masters](https://github.com/datascienc
 
 **Mobile Software Development**
 
-> [Stanford CS193p — Developing Apps for iOS (SwiftUI)](https://cs193p.sites.stanford.edu/)  
+> [Stanford CS193p — Developing Apps for iOS (SwiftUI)](https://cs193p.stanford.edu/)  
 > *or*  
 > [Google — Android Basics with Compose](https://developer.android.com/courses/android-basics-compose/course)
 


### PR DESCRIPTION
## What does this PR change?

Updates three outdated course resource links in the README:
- Interaction Design Foundation UX course: shortened domain from `interaction-design.org` to `ixdf.org`
- freeCodeCamp Responsive Web Design: removed trailing slash from URL
- Stanford CS193p iOS development: updated domain from `cs193p.sites.stanford.edu` to `cs193p.stanford.edu`

## Related issue

<!-- Closes #N, if applicable -->

## Checklist

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] One focused change per PR (link fix, course swap, etc.)
- [ ] Any new course meets the criteria in CONTRIBUTING.md
- [ ] Link checker is passing (it runs automatically on this PR)

https://claude.ai/code/session_01XCxNxCVG7Ry8iRsVzWHXkN