### PR TITLE
Fix broken UC Berkeley course links (CS61C, CS188, CS169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Inspired by [The Open-Source Data Science Masters](https://github.com/datascienc
 > *or*  
 > [MIT 6.823](https://ocw.mit.edu/courses/6-823-computer-system-architecture-fall-2005/)  
 > *or*  
-> [UC Berkeley CS61C](https://inst.eecs.berkeley.edu/~cs61c/)
+> [UC Berkeley CS61C](https://cs61c.org/)
 
 ### Term 2
 
@@ -94,7 +94,7 @@ Inspired by [The Open-Source Data Science Masters](https://github.com/datascienc
 
 > [MIT 6.005 — Software Construction](https://ocw.mit.edu/courses/6-005-software-construction-spring-2016/)  
 > *or*  
-> [UC Berkeley CS169](https://inst.eecs.berkeley.edu/~cs169/)
+> [UC Berkeley CS169](https://saasbook.info/)
 
 **Principles of Computing**
 
@@ -124,7 +124,7 @@ Inspired by [The Open-Source Data Science Masters](https://github.com/datascienc
 
 > [MIT 6.034](https://ocw.mit.edu/courses/6-034-artificial-intelligence-fall-2010/)  
 > *or*  
-> [UC Berkeley CS188](https://inst.eecs.berkeley.edu/~cs188/)
+> [UC Berkeley CS188](https://ai.berkeley.edu/)
 
 **Parallel Computing**
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Inspired by [The Open-Source Data Science Masters](https://github.com/datascienc
 
 > [MIT 6.034](https://ocw.mit.edu/courses/6-034-artificial-intelligence-fall-2010/)  
 > *or*  
-> [UC Berkeley CS188](https://ai.berkeley.edu/)
+> [UC Berkeley CS188 (lecture videos)](https://www.youtube.com/playlist?list=PLtFb24pIhyHv6d6OqDr_tVaygbj86mCGA)
 
 **Parallel Computing**
 


### PR DESCRIPTION
## What does this PR change?

The `inst.eecs.berkeley.edu/~csNNN/` course pages are no longer public — they now sit behind CalNet login or 404 at the root. This points each affected course to its public home:

- **CS61C** (Computer Architecture) → `https://cs61c.org/` — the course's public domain, same pattern as the CS61A/CS162 links already in the README.
- **CS188** (Artificial Intelligence) → Berkeley's official staff-curated [CS188 lecture playlist on YouTube](https://www.youtube.com/playlist?list=PLtFb24pIhyHv6d6OqDr_tVaygbj86mCGA). The `ai.berkeley.edu` hub only links enrolled-student semester sites rather than a free course, so this uses the complete, publicly free video series instead.
- **CS169** (Software Engineering) → `https://saasbook.info/` — the course's public home. Not separately reported, but it's on the same dead domain and fails identically.

## Related issue

Closes #36
Closes #37

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] One focused change per PR (link fix, course swap, etc.)
- [x] Any new course meets the criteria in CONTRIBUTING.md
- [ ] Link checker is passing (it runs automatically on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCxNxCVG7Ry8iRsVzWHXkN)_